### PR TITLE
libj1939: src: j1939_ecu.c: Change seqno start number from 0 to 1.

### DIFF
--- a/src/j1939_ecu.c
+++ b/src/j1939_ecu.c
@@ -66,7 +66,7 @@ static int defrag_send(uint16_t size, const uint8_t priority, const uint8_t src,
 		       const uint8_t dest, uint8_t *data)
 {
 	int ret;
-	uint8_t seqno = 0;
+	uint8_t seqno = 1;
 	uint8_t frame[DLC_MAX];
 
 	while (size > 0) {


### PR DESCRIPTION
The sequence number should start from 1 and follows upto 255.

Transport protocol = (255 * 7) = 1785bytes.

Signed-off-by: NavinSankar Velliangiri <navin@linumiz.com>